### PR TITLE
Fixed a buffer overflow bug

### DIFF
--- a/src/bgnet.xml
+++ b/src/bgnet.xml
@@ -4358,7 +4358,7 @@ void unpack(unsigned char *buf, char *format, ...)
 			s = va_arg(ap, char*);
 			len = unpacku16(buf);
 			buf += 2;
-			if (maxstrlen > 0 && len > maxstrlen) count = maxstrlen - 1;
+			if (maxstrlen > 0 && len >= maxstrlen) count = maxstrlen - 1;
 			else count = len;
 			memcpy(s, buf, count);
 			s[count] = '\0';


### PR DESCRIPTION
If you consider the possibility that len could be equal to maxstrlen then you'd be writing out of boundaries in the line "s[count] ='\0';" as count would be equal to maxstrlen.
It might be that your concept of maxstrlen included the whole string, but then "count = maxstrlen - 1;" makes no sense, as, if that was the case, you'd have simply written "count = maxstrlen;".
In any case, it's possible to trigger an out-of-bounds memory write, therefore this constitutes a memory bug.