### PR TITLE
Add build instructions for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.8.2
+
+RUN apt-get update && apt-get install -y pandoc texlive-xetex fonts-liberation && apt-get clean
+
+WORKDIR /guide
+
+CMD make -e SHELL=/bin/bash pristine all stage

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ the top-level `Makefile` to point to your host if you want to use that.
 You're free to upload whatever versions you desire individually, as
 well.
 
+### Build via Docker
+
+If you don't want to mess with a local setup, you can build via Docker.
+
+1. Run `docker build -t beej-bgnet-builder .` from the top-level directory.
+
+2. Run `docker run --rm -v "$PWD":/guide -ti beej-bgnet-builder`.
+
+   This will mount the project where the image expects it, and run `make
+   pristine all stage`, leaving your `./stage` directory ready to be published.
+
 ## Pull Requests
 
 Please keep these on the scale of typo and bug fixes. That way I don't


### PR DESCRIPTION
I'll plan to use them for a Spanish translation, but I think it's useful overall.

I plan to publish an image in Docker Hub, too - but I'm not sure whether to use that in the instructions or leave them as they are.