### PR TITLE
Moving broken links for Danish, Estonian, Farsi, Serbian, Turkish, Uzbek

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -148,9 +148,6 @@
 			-->
 			<li><a href="http://beej-zhcn.netdpi.net">Simplified Chinese</a>
 			<li><a href="http://beej-zhtw.netdpi.net">Traditional Chinese</a>
-			<li><a href="http://artcreationforever.com/bgnet.html">Danish</a>
-			<li><a href="http://www.bildelarstore.se/science/beej-juhend-vorgustik-kavandamise/">Estonian</a>
-			<li><a href="http://weknownyourdreamz.com/bgnet.html">Farsi<a>
 			<li><a href="http://www.chez.com/vidalc/lf/socket.html">French</a>
 			<li><a href="http://www.tobscore.com/socket-programmierung-in-c/">German</a>
 			<li><a href="http://weknowyourdreams.com/bgnet-sw.html">Hungarian</a>
@@ -161,10 +158,7 @@
 			<li><a href="http://www.asawicki.info/Mirror/Beej_s%20Guide%20to%20Network%20Programming%20PL/bgnet.pdf">Polish</a>
 			<li><a href="http://weknowyourdreams.com/beej.html">Romanian</a>
 			<li><a href="translations/bgnet_A4_rus.pdf">Russian</a>
-			<li><a href="http://users.teol.net/~mvlado/sockets/">Serbian</a>
 			<li><a href="http://weknowyourdreams.com/bgnet.html">Swedish</a>
-			<li><a href="http://www.belgeler.org/bgnet/bgnet.html">Turkish</a>
-			<li><a href="http://clipartmag.com/ru-bgnet">Uzbek</a>
 			</ul>
 
 			<p><b>Broken translation links</b>
@@ -172,9 +166,15 @@
 
 			<ul>
 			<li><a href="http://docs.chinalinuxpub.com/doc/pro/is.html">Chinese</a>
+			<li><a href="http://artcreationforever.com/bgnet.html">Danish</a>
 			<li><a href="http://analyser.oli.tudelft.nl/beej/translations/net/">Dutch</a>
+			<li><a href="http://www.bildelarstore.se/science/beej-juhend-vorgustik-kavandamise/">Estonian</a>
+			<li><a href="http://weknownyourdreamz.com/bgnet.html">Farsi<a>
 			<li><a href="http://yuval.anibo-soft.com/beej/">Hebrew</a>
+			<li><a href="http://users.teol.net/~mvlado/sockets/">Serbian</a>
 			<li><a href="http://www.arrakis.es/~dmrq/beej/home.htm">Spanish</a>
+			<li><a href="http://www.belgeler.org/bgnet/bgnet.html">Turkish</a>
+			<li><a href="http://clipartmag.com/ru-bgnet">Uzbek</a>
 			</ul>
 
 			<p>


### PR DESCRIPTION
The links for those translations are broken, so I have moved them down to the 'Broken translation links' section.

Affected languages: Danish, Estonian, Farsi, Serbian, Turkish, Uzbek.