### PR TITLE
Fix pollserver.c uninitialized read

### DIFF
--- a/source/examples/pollserver.c
+++ b/source/examples/pollserver.c
@@ -88,6 +88,9 @@ void add_to_pfds(struct pollfd *pfds[], int newfd, int *fd_count, int *fd_size)
 
     (*pfds)[*fd_count].fd = newfd;
     (*pfds)[*fd_count].events = POLLIN; // Check ready-to-read
+    (*pfds)[*fd_count].revents = 0;
+    // revents should be set because it'll be read in the next iteration of pfds
+    // before `poll` touches it
 
     (*fd_count)++;
 }


### PR DESCRIPTION
In `add_to_pfds`, `revents` is uninitialized. But that flag will be read in the next iteration of `pfds`. It should be set to 0 to avoid uninitialized read.